### PR TITLE
perf: Ensure `in.available()` check for proper stream processing in VoteReceiver (v2 protocol)

### DIFF
--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
@@ -300,7 +300,7 @@ public abstract class VoteReceiver extends Thread {
 					// In V2 mode, always parse as JSON.
 					ByteArrayOutputStream voteDataStream = new ByteArrayOutputStream();
 					int b;
-					while ((b = in.read()) != -1) {
+					while (in.available() > 0 && (b = in.read()) != -1) {
 						voteDataStream.write(b);
 					}
 					voteData = voteDataStream.toString("UTF-8").trim();


### PR DESCRIPTION
## Summary

This pull request improves the performance of the `VoteReceiver` class when handling V2 protocol votes by avoiding unnecessary blocking on input stream reads.

## Background

Previously, when handling a V2 vote packet, the following logic was used to read from the input stream:

```java
while ((b = in.read()) != -1) {
    voteDataStream.write(b);
}
```

However, we observed that the process would often stall for up to 5 seconds between:

```
Detected vote protocol version: V2
```

and

```
Received raw V2 vote payload: [...]
```

## Root Cause

The `InputStream.read()` method is a blocking call and would wait for more data or for the stream to close. In our case, this behavior led to significant delays even though the full payload was already available.

## Fix

We modified the loop to include a check on `in.available()` before each read:

```java
while (in.available() > 0 && (b = in.read()) != -1) {
    voteDataStream.write(b);
}
```

This ensures we only attempt to read bytes when they are immediately available, avoiding the blocking behavior of `read()`.

## Result

With this change, the 5-second stall no longer occurs. The vote data is processed immediately after the protocol version is detected, significantly improving the responsiveness of the V2 vote handler.

### Before

```
[03:47:31 INFO]: [VotifierPlus] Debug: Accepted connection from: /172.19.0.1:56992
[03:47:31 INFO]: [VotifierPlus] Debug: Sent handshake: VOTIFIER 2 4abbcspvcnksp3382dr9ei75n0                                                                                                                                        
[03:47:31 INFO]: [VotifierPlus] Debug: Detected vote protocol version: V2
[03:47:36 INFO]: [VotifierPlus] Debug: Received raw V2 vote payload: [s:�{"payload":"{\"username\":\"Test user\",\"address\":\"\",\"timestamp\":1752378451719,\"serviceName\":\"MinePortal\",\"challenge\":\"4abbcspvcnksp3382dr9ei75n0\"}","signature":"mogecUYoTsIxMy3CBc7P9BTeXVXLKlH9hswea8/tMCA="}]
[03:47:36 INFO]: [VotifierPlus] Debug: Extracted raw JSON payload: [{"payload":"{\"username\":\"Test user\",\"address\":\"\",\"timestamp\":1752378451719,\"serviceName\":\"MinePortal\",\"challenge\":\"4abbcspvcnksp3382dr9ei75n0\"}","signature":"mogecUYoTsIxMy3CBc7P9BTeXVXLKlH9hswea8/tMCA="}]                                                                                                                                                                     
[03:47:36 INFO]: [VotifierPlus] Debug: Inner payload string: [{"username":"Test user","address":"","timestamp":1752378451719,"serviceName":"MinePortal","challenge":"4abbcspvcnksp3382dr9ei75n0"}]                                  
[03:47:36 INFO]: [VotifierPlus] Received vote record -> Vote (from:MinePortal username:Test user address: timeStamp:1752378451719)                                                                                                  
[03:47:36 INFO]: [VotifierPlus] Debug: Sent OK response: {"status":"ok"}
```

As shown above, there was a **5-second delay** between detecting the protocol version and receiving the vote payload. This was due to blocking behavior in the `in.read()` loop, which waited for the stream to close or for more data to arrive.

### After

```
[03:46:05 INFO]: [VotifierPlus] Debug: Accepted connection from: /172.19.0.1:40778
[03:46:05 INFO]: [VotifierPlus] Debug: Sent handshake: VOTIFIER 2 kuinn0bpev719r8r3dh97jl57j                                                                                                                                        
[03:46:05 INFO]: [VotifierPlus] Debug: Detected vote protocol version: V2
[03:46:05 INFO]: [VotifierPlus] Debug: Received raw V2 vote payload: [s:�{"payload":"{\"username\":\"Test user\",\"address\":\"\",\"timestamp\":1752378365771,\"serviceName\":\"MinePortal\",\"challenge\":\"kuinn0bpev719r8r3dh97jl57j\"}","signature":"qO9GJfot0slOf2DMvqXaE80fNRi5LearVIu2MsnTtCs="}]                                                                                                                                                                
[03:46:05 INFO]: [VotifierPlus] Debug: Extracted raw JSON payload: [{"payload":"{\"username\":\"Test user\",\"address\":\"\",\"timestamp\":1752378365771,\"serviceName\":\"MinePortal\",\"challenge\":\"kuinn0bpev719r8r3dh97jl57j\"}","signature":"qO9GJfot0slOf2DMvqXaE80fNRi5LearVIu2MsnTtCs="}]                                                                                                                                                                     
[03:46:05 INFO]: [VotifierPlus] Debug: Inner payload string: [{"username":"Test user","address":"","timestamp":1752378365771,"serviceName":"MinePortal","challenge":"kuinn0bpev719r8r3dh97jl57j"}]                                  
[03:46:05 INFO]: [VotifierPlus] Received vote record -> Vote (from:MinePortal username:Test user address: timeStamp:1752378365771, sourceAddress:/172.19.0.1:40778)                                                                 
[03:46:05 INFO]: [VotifierPlus] Debug: Sent OK response: {"status":"ok"}
```

After the fix, the log lines appear **instantaneously** (within the same second), indicating that the vote payload is processed as soon as it becomes available.

### Explanation

The logs demonstrate the effectiveness of the fix:

* In the "Before" logs, the `Detected vote protocol version: V2` message is followed by a 5-second pause before the payload is processed.
* In the "After" logs, all steps — from protocol detection to payload extraction and vote handling — occur within the same second.
* This confirms that replacing `while ((b = in.read()) != -1)` with `while (in.available() > 0 && (b = in.read()) != -1)` prevents the input stream from blocking unnecessarily.

This change results in faster vote processing and a more responsive vote receiving system.