### PR TITLE
Fix proxy vote receiver reload lifecycle

### DIFF
--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/bungee/VotifierPlusBungee.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/bungee/VotifierPlusBungee.java
@@ -126,9 +126,21 @@ public class VotifierPlusBungee extends Plugin {
 	}
 
 	public void reload() {
+		if (voteReceiver != null) {
+			voteReceiver.shutdown();
+			voteReceiver = null;
+		}
 		config.load();
 		loadTokens();
 		loadVoteReceiver();
+	}
+
+	@Override
+	public void onDisable() {
+		if (voteReceiver != null) {
+			voteReceiver.shutdown();
+			voteReceiver = null;
+		}
 	}
 
 	private void loadVoteReceiver() {

--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/bungee/VotifierPlusCommand.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/bungee/VotifierPlusCommand.java
@@ -48,7 +48,7 @@ public class VotifierPlusCommand extends Command {
 					}
 					sender.sendMessage(new TextComponent("New keys generated"));
 				}
-				if (args[0].equalsIgnoreCase("vote") && args.length > 2) {
+				if ((args[0].equalsIgnoreCase("test") || args[0].equalsIgnoreCase("vote")) && args.length > 2) {
 					try {
 						PublicKey publicKey = bungee.getKeyPair().getPublic();
 						String serverIP = bungee.getConfig().getHost();

--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlusVelocity.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlusVelocity.java
@@ -76,7 +76,10 @@ public class VotifierPlusVelocity {
 
 	@Subscribe
 	public void onProxyDisable(ProxyShutdownEvent event) {
-		voteReceiver.shutdown();
+		if (voteReceiver != null) {
+			voteReceiver.shutdown();
+			voteReceiver = null;
+		}
 	}
 
 	private HashMap<String, Key> tokens = new HashMap<String, Key>();
@@ -184,7 +187,6 @@ public class VotifierPlusVelocity {
 				// Specify other aliases (optional)
 				.aliases("votifierplus", "votifierplusvelocity").build();
 		server.getCommandManager().register(meta, new VotifierPlusVelocityCommand(this));
-		loadVoteReceiver();
 		File rsaDirectory = new File(dataDirectory.toFile(), "rsa");
 		/*
 		 * Create RSA directory and keys if it does not exist; otherwise, read keys.
@@ -201,6 +203,7 @@ public class VotifierPlusVelocity {
 			logger.error("Error reading configuration file or RSA keys");
 			return;
 		}
+		loadVoteReceiver();
 
 		try {
 			getVersionFile();
@@ -224,9 +227,9 @@ public class VotifierPlusVelocity {
 
 	}
 
-	private void loadVoteReceiver() {
+	private boolean loadVoteReceiver() {
 		try {
-			voteReceiver = new VoteReceiver(config.getHost(), config.getPort()) {
+			VoteReceiver receiver = new VoteReceiver(config.getHost(), config.getPort()) {
 
 				@Override
 				public void logWarning(String warn) {
@@ -353,17 +356,24 @@ public class VotifierPlusVelocity {
 				}
 
 			};
-			voteReceiver.start();
+			receiver.start();
+			voteReceiver = receiver;
 
 			logger.info("Votifier enabled.");
+			return true;
 		} catch (Exception ex) {
-			return;
+			logger.error("Unable to start Votifier vote receiver.", ex);
+			return false;
 		}
 	}
 
-	public void reload() {
+	public boolean reload() {
+		if (voteReceiver != null) {
+			voteReceiver.shutdown();
+			voteReceiver = null;
+		}
 		config.reload();
 		loadTokens();
-		loadVoteReceiver();
+		return loadVoteReceiver();
 	}
 }

--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlusVelocityCommand.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlusVelocityCommand.java
@@ -31,8 +31,12 @@ public class VotifierPlusVelocityCommand implements SimpleCommand {
 		if (hasPermission(invocation)) {
 			if (args.length > 0) {
 				if (args[0].equalsIgnoreCase("reload")) {
-					plugin.reload();
-					source.sendMessage(Component.text("Reloading VotifierPlus").color(NamedTextColor.AQUA));
+					if (plugin.reload()) {
+						source.sendMessage(Component.text("Reloaded VotifierPlus").color(NamedTextColor.AQUA));
+					} else {
+						source.sendMessage(Component.text("Failed to reload VotifierPlus; check the proxy log.")
+								.color(NamedTextColor.RED));
+					}
 				}
 				if (args[0].equalsIgnoreCase("GenerateKeys")) {
 					File rsaDirectory = new File(plugin.getDataDirectory() + File.separator + "rsa");
@@ -52,7 +56,7 @@ public class VotifierPlusVelocityCommand implements SimpleCommand {
 					}
 					source.sendMessage(Component.text("New keys generated"));
 				}
-				if (args[0].equalsIgnoreCase("vote") && args.length > 2) {
+				if ((args[0].equalsIgnoreCase("test") || args[0].equalsIgnoreCase("vote")) && args.length > 2) {
 					try {
 						PublicKey publicKey = plugin.getKeyPair().getPublic();
 						String serverIP = plugin.getConfig().getHost();


### PR DESCRIPTION
## What changed

- Shut down the existing vote receiver before reloading it on both BungeeCord and Velocity, preventing a second bind to the configured Votifier port.
- Shut down the Bungee receiver during plugin disable.
- Accept the documented `test` proxy subcommand while retaining `vote` as a compatibility alias.
- On Velocity, initialize RSA keys before starting the receiver, avoid replacing the active receiver until startup succeeds, and report reload failures to the command sender and log.

## Root cause

Proxy reload paths created a new `VoteReceiver` without closing the current listener. The second `ServerSocket` bind therefore fails with `BindException: Address already in use`, leaving reload broken. The proxy command implementations also only recognized `vote`, although the documented command is `test`; `test` was silently ignored.

## Impact

Proxy administrators can reload VotifierPlus without leaking the listener, and `/votifierplus test <player> <service>` now triggers a test vote on BungeeCord and Velocity.

## Validation

- Reviewed the one-commit diff against `master`.
- `git diff --check` passed.
- Maven tests could not run in this environment because `mvn` is not installed.