### PR TITLE
Reduce unnecessary Maven repository lookups

### DIFF
--- a/VotifierPlus/pom.xml
+++ b/VotifierPlus/pom.xml
@@ -122,6 +122,12 @@
                             <groupId>com.velocitypowered</groupId>
                             <artifactId>velocity-api</artifactId>
                             <version>${velocity.version}</version>
+                            <exclusions>
+                                <exclusion>
+                                    <groupId>com.velocitypowered</groupId>
+                                    <artifactId>velocity-brigadier</artifactId>
+                                </exclusion>
+                            </exclusions>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -295,6 +301,12 @@
             <artifactId>velocity-api</artifactId>
             <version>${velocity.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.velocitypowered</groupId>
+                    <artifactId>velocity-brigadier</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/VotifierPlus/pom.xml
+++ b/VotifierPlus/pom.xml
@@ -243,24 +243,39 @@
     </build>
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>bencodez repo</id>
-            <url>https://nexus.bencodez.com/repository/maven-public/</url>
-        </repository>
-        <repository>
-            <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
-            <id>papermc</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>velocity</id>
             <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>bencodez repo</id>
+            <url>https://nexus.bencodez.com/repository/maven-public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <dependencies>

--- a/VotifierPlus/pom.xml
+++ b/VotifierPlus/pom.xml
@@ -257,13 +257,6 @@
             </releases>
         </repository>
         <repository>
-            <id>velocity</id>
-            <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>bencodez repo</id>
             <url>https://nexus.bencodez.com/repository/maven-public/</url>
             <snapshots>


### PR DESCRIPTION
## Summary

- put Maven Central first for normal release dependencies
- make the Spigot repository snapshot-only
- remove the obsolete Sonatype/BungeeCord snapshot repository
- remove the unresponsive Velocity repository; `velocity-api:3.4.0` resolves from Paper
- disable snapshot resolution for the release-only BenCodez and Paper repositories
- exclude the unused `velocity-brigadier:1.0.0-SNAPSHOT` transitive dependency from the Velocity API dependency and annotation-processor path

## Why

Jenkins build 846, triggered by SimpleAPI build 231, resolved the Spigot `1.21.9-R0.1-SNAPSHOT` metadata successfully from Spigot and Paper, then stalled while Maven waited for the same snapshot metadata from unrelated repositories.

This is the same unnecessary cross-repository metadata lookup pattern fixed in BenCodez/VotingPlugin#1555. VotifierPlus uses the released `com.bencodez:simpleapi:1.0`, so BenCodez snapshot resolution is not required here.

A first CI run confirmed that Maven no longer hung on Spigot snapshot metadata, but the Velocity Nexus then timed out while resolving `velocity-api:3.4.0`. Paper serves that exact release. After removing Velocity Nexus, Maven exposed its optional `velocity-brigadier` snapshot; VotifierPlus only uses Velocity's simple command API and does not reference Brigadier, so the same exclusion already used by VotingPlugin is applied here.

## Validation

- `pom.xml` parses as well-formed XML
- direct artifact checks:
  - Spigot snapshot metadata: available from Spigot
  - `simpleapi:1.0`: available from BenCodez Nexus
  - `bungeecord-api:1.21-R0.4`: available from Maven Central
  - `velocity-api:3.4.0`: available from Paper
  - Velocity Nexus request timed out with zero bytes
- GitHub Actions `mvn -B -f VotifierPlus/pom.xml package`: **passed in 38 seconds**
- change is limited to repository policies plus the unused Brigadier transitive exclusion