### PR TITLE
Fix MinePortal V2 compatibility regression

### DIFF
--- a/VotifierPlus/src/main/java/com/vexsoftware/votifier/net/VoteParser.java
+++ b/VotifierPlus/src/main/java/com/vexsoftware/votifier/net/VoteParser.java
@@ -538,9 +538,9 @@ public class VoteParser {
 
 		String serviceName = requireString(votePayload, FIELD_SERVICE_NAME, "Inner JSON from " + address + ": ");
 		String username = requireString(votePayload, FIELD_USERNAME, "Inner JSON from " + address + ": ");
-		String voteAddress = requireString(votePayload, FIELD_ADDRESS, "Inner JSON from " + address + ": ");
+		String voteAddress = votePayload.get(FIELD_ADDRESS).getAsString();
 		String timeStamp = requireString(votePayload, FIELD_TIMESTAMP, "Inner JSON from " + address + ": ");
-		String receivedChallenge = requireString(votePayload, FIELD_CHALLENGE, "Inner JSON from " + address + ": ");
+		String receivedChallenge = requireString(votePayload, FIELD_CHALLENGE, "Inner JSON from " + address + ": ").trim();
 
 		Map<String, Key> tokens = receiver.getTokens();
 		Key key = tokens.get(serviceName);


### PR DESCRIPTION
This fixes a regression affecting MinePortal Votifier v2 votes.

MinePortal may send:
- an empty `address` field
- a challenge with trailing whitespace / CR

VotifierPlus previously handled the challenge case by trimming the received challenge, but that behavior was lost during the VoteParser refactor. The newer strict string validation also rejects an empty `address`, which MinePortal can legitimately send.

Changes:
- allow an empty V2 `address` value while still requiring the field itself
- trim the received V2 challenge before comparison

Verified on Velocity with VotifierPlus 1.4.4-SNAPSHOT dev build 850.

Before:
- `Authentication failed ... Invalid challenge`
- `Invalid vote format ... empty field 'address'`

After:
- `Received vote record -> Vote (from:MinePortal ...)`
- VotingPlugin successfully receives the vote
